### PR TITLE
feat(auth): Add styles for auth pages

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -2,7 +2,15 @@
 import {useHead} from "#imports"
 
 useHead({
-  title: "Twilight's Library"
+  titleTemplate(title) {
+    const base = "Twilight's Library"
+
+    if (title) {
+      return `${title} – ${base}`
+    }
+
+    return base
+  },
 })
 </script>
 

--- a/app.vue
+++ b/app.vue
@@ -6,12 +6,20 @@ useHead({
 })
 </script>
 
-<template>
-  <div>
-    <NuxtLayout>
-      <NuxtLoadingIndicator :color="false" class="bg-blue-500" />
+<style lang="postcss">
+body {
+  @apply bg-white dark:bg-neutral-900 dark:text-white;
+}
 
-      <NuxtPage />
-    </NuxtLayout>
-  </div>
+a {
+  @apply underline dark:text-neutral-400;
+}
+</style>
+
+<template>
+  <NuxtLayout>
+    <NuxtLoadingIndicator :color="false" class="bg-blue-500" />
+
+    <NuxtPage />
+  </NuxtLayout>
 </template>

--- a/components/Button.vue
+++ b/components/Button.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+type Variants = "primary" | "secondary"
+
+type Colors = "red" | "brand"
+
+type Shapes = "square" | "circle"
+
+// ! Vue doesn't support this kind of props
+interface Props {
+  variant?: Variants
+  color?: Colors
+  shape?: Shapes
+  wide?: boolean
+  disabled?: boolean
+  loading?: boolean
+}
+
+withDefaults(defineProps<Props>(), {
+  variant: "primary",
+  shape: "square",
+  disabled: false,
+  wide: ({wide = false, shape}) => shape === "circle" ? false : wide
+})
+</script>
+
+<template>
+  <button
+    :disabled="disabled"
+    :class='[
+      "text-center border",
+
+      {
+        "w-full": wide,
+        "p-3 rounded-md": shape === "square",
+        "p-2 rounded-full": shape === "circle",
+        "relative cursor-progress": loading,
+        "disabled:cursor-not-allowed": disabled && !loading,
+        "disabled:bg-gray-400 disabled:dark:bg-slate-600": (variant === "primary" && !loading),
+        "disabled:border-gray-300 disabled:text-gray-300 bg-transparent active:disabled:bg-transparent dark:disabled:border-slate-500 dark:disabled:text-slate-500": variant === "secondary",
+        "bg-violet-500 active:bg-violet-600 border-violet-500 text-white": variant === "primary" && (!color || color === "brand"),
+        "bg-white active:bg-gray-200 dark:bg-slate-700 dark:text-white dark:active:bg-slate-600": variant === "secondary",
+        "border-gray-200 bg-white active:bg-gray-200 text-black": variant === "secondary" && !color,
+        "bg-red-500 active:bg-red-600 text-white": variant === "primary" && color === "red",
+        "border-violet-500 text-violet-500 active:bg-violet-200": variant === "secondary" && color === "brand",
+        "border-red-500 text-red-500 active:bg-red-100": variant === "secondary" && color === "red"
+      }
+    ]'>
+      <slot />
+    </button>
+</template>

--- a/components/Field.vue
+++ b/components/Field.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <slot />
+  </div>
+</template>

--- a/components/Input.vue
+++ b/components/Input.vue
@@ -1,19 +1,24 @@
 <script setup lang="ts">
 interface Props {
   wide?: boolean
+  modelValue?: string
 }
 
 defineProps<Props>()
+defineEmits(["update:modelValue"])
 </script>
 
 <template>
   <input
-  :class='[
+    :class='[
       "p-3 border border-gray-300 text-neutral-500 dark:text-neutral-400 rounded-md dark:bg-neutral-900 dark:border-neutral-600",
 
       {
         "w-full": wide === true
       },
     ]'
+
+    :value="modelValue"
+    @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
   />
 </template>

--- a/components/Input.vue
+++ b/components/Input.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+interface Props {
+  wide?: boolean
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <input
+  :class='[
+      "p-3 border border-gray-300 text-neutral-500 dark:text-neutral-400 rounded-md dark:bg-neutral-900 dark:border-neutral-600",
+
+      {
+        "w-full": wide === true
+      },
+    ]'
+  />
+</template>

--- a/components/Label.vue
+++ b/components/Label.vue
@@ -1,0 +1,5 @@
+<template>
+  <label class="w-full text-neutral-500 dark:text-neutral-400">
+    <slot />
+  </label>
+</template>

--- a/components/form/Auth.vue
+++ b/components/form/Auth.vue
@@ -1,6 +1,6 @@
 <template>
-  <form class="flex flex-col gap-8 py-10 px-7 border border-gray-100 dark:border-neutral-600 shadow-2xl dark:shadow-none rounded-lg bg-white dark:bg-neutral-800">
-    <div class="text-3xl">
+  <form class="flex flex-col gap-8 py-12 px-10 border border-gray-100 dark:border-neutral-600 shadow-2xl dark:shadow-none rounded-lg bg-white dark:bg-neutral-800">
+    <div class="text-3xl select-none">
       <slot name="title" />
     </div>
 

--- a/components/form/Auth.vue
+++ b/components/form/Auth.vue
@@ -1,0 +1,23 @@
+<template>
+  <form class="flex flex-col gap-8 py-10 px-7 border border-gray-100 dark:border-neutral-600 shadow-2xl dark:shadow-none rounded-lg bg-white dark:bg-neutral-800">
+    <div class="text-3xl">
+      <slot name="title" />
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <slot />
+    </div>
+
+    <div>
+      <slot name="actions">
+        <Button wide type="submit">
+          <slot name="submit" />
+        </Button>
+      </slot>
+    </div>
+
+    <div class="text-sm">
+      <slot name="links" />
+    </div>
+  </form>
+</template>

--- a/layouts/auth.vue
+++ b/layouts/auth.vue
@@ -4,6 +4,8 @@ import FullscreenMain from "../components/FullscreenMain.vue"
 
 <template>
   <FullscreenMain>
-    <slot />
+    <div class="w-full m-auto p-5 mobile:w-mobile">
+      <slot />
+    </div>
   </FullscreenMain>
 </template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,9 +11,6 @@ export default defineNuxtConfig({
     asyncContext: true,
     headNext: true
   },
-  imports: {
-    autoImport: false
-  },
   modules: [
     "@nuxtjs/tailwindcss",
     "@sidebase/nuxt-auth"

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -1,12 +1,4 @@
 <script setup lang="ts">
-import {
-  definePageMeta,
-  useHead,
-  useIsFormVaid,
-  useAuth,
-  useRouter
-} from "#imports"
-
 import {useForm} from "@vorms/core"
 import {zodResolver} from "@vorms/resolvers/zod"
 
@@ -35,12 +27,13 @@ useHead({
 const {replace} = useRouter()
 const {signIn} = useAuth()
 
-const {register, handleSubmit, errors} = useForm<IUserLogInInput>({
+const {register, handleSubmit} = useForm<IUserLogInInput>({
   initialValues: {
     login: "",
     password: ""
   },
   validate: zodResolver(UserLogInInput),
+  validateOnMounted: true,
   validateMode: "input",
   reValidateMode: "input",
   async onSubmit(data) {
@@ -57,33 +50,66 @@ const {register, handleSubmit, errors} = useForm<IUserLogInInput>({
   }
 })
 
-const {isInvalid} = useIsFormVaid(errors)
-
 const {value: loginValue, attrs: loginAttrs} = register("login")
-
 const {value: passwordValue, attrs: passwordAttrs} = register("password")
 </script>
 
 <template>
-  <form @submit="handleSubmit">
-    <input
-      type="text"
-      class="border"
-      placeholder="Login"
-      v-model="loginValue"
-      v-bind="loginAttrs"
-    />
+  <FormAuth @submit="handleSubmit">
+    <template #title>
+      Login
+    </template>
 
-    <input
-      type="password"
-      class="border"
-      placeholder="Password"
-      v-model="passwordValue"
-      v-bind="passwordAttrs"
-    />
+    <Field>
+      <Label for="login">
+        Your login
+      </Label>
 
-    <button type="submit" :disabled="isInvalid">
+      <Input
+        wide
+        id="login"
+        class="mb-2"
+        type="text"
+        placeholder="Login..."
+        v-model="loginValue"
+        v-bind="loginAttrs"
+      />
+    </Field>
+
+    <Field>
+      <Label for="login" class="text-neutral-500 dark:text-neutral-400">
+        Your password
+      </Label>
+
+      <Input
+        wide
+        class="mb-2"
+        type="password"
+        placeholder="Password..."
+        v-model="passwordValue"
+        v-bind="passwordAttrs"
+      />
+    </Field>
+
+    <template #submit>
       Log in
-    </button>
-  </form>
+    </template>
+
+    <template #links>
+      <!-- <div class="h-px w-full bg-neutral-600" /> -->
+      <div class="text-center flex flex-col gap-2">
+        <div>
+          <NuxtLink href="/auth/reset">
+            Forgot your password?
+          </NuxtLink>
+        </div>
+
+        <div>
+          <NuxtLink href="/auth/signup">
+            Don't have an account? Sign up here
+          </NuxtLink>
+        </div>
+      </div>
+    </template>
+  </FormAuth>
 </template>

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -96,7 +96,6 @@ const {value: passwordValue, attrs: passwordAttrs} = register("password")
     </template>
 
     <template #links>
-      <!-- <div class="h-px w-full bg-neutral-600" /> -->
       <div class="text-center flex flex-col gap-2">
         <div>
           <NuxtLink href="/auth/reset">

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type {AuthMeta} from "../../lib/auth/AuthMeta.js"
+
 definePageMeta({
   layout: "auth",
   middleware: "auth",

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -10,10 +10,30 @@ definePageMeta({
       Restore password
     </template>
 
-    <Input placeholder="Email..." />
+    <div class="flex flex-col gap-8">
+      <Field>
+        <Label for="email">
+          Your email address
+        </Label>
+
+        <Input id="email" placeholder="Email..." />
+      </Field>
+
+      <div class="text-center p-3 border border-neutral-700 border-dotted rounded-md select-none">
+        The instructions will be send to this email address, so fill this field carefully.
+      </div>
+    </div>
 
     <template #submit>
       Restore password
+    </template>
+
+    <template #links>
+      <div class="text-center flex flex-col gap-2">
+        <NuxtLink href="/auth/login">
+          Log in here if you remember your password
+        </NuxtLink>
+      </div>
     </template>
   </FormAuth>
 </template>

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: "auth"
+})
+</script>
+
+<template>
+  <FormAuth>
+    <template #title>
+      Restore password
+    </template>
+
+    <Input placeholder="Email..." />
+
+    <template #submit>
+      Restore password
+    </template>
+  </FormAuth>
+</template>

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import type {AuthMeta} from "../../lib/auth/AuthMeta.js"
 
+useHead({
+  title: "Reset password"
+})
+
 definePageMeta({
   layout: "auth",
   middleware: "auth",

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -18,7 +18,7 @@ definePageMeta({
 <template>
   <FormAuth>
     <template #title>
-      Restore password
+      Reset password
     </template>
 
     <div class="flex flex-col gap-8">
@@ -36,7 +36,7 @@ definePageMeta({
     </div>
 
     <template #submit>
-      Restore password
+      Send instructions
     </template>
 
     <template #links>

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 definePageMeta({
-  layout: "auth"
+  layout: "auth",
+  middleware: "auth",
+  auth: {
+    unauthenticatedOnly: true,
+    navigateAuthenticatedTo: "/"
+  } satisfies AuthMeta
 })
 </script>
 

--- a/pages/auth/signup.vue
+++ b/pages/auth/signup.vue
@@ -1,12 +1,4 @@
 <script setup lang="ts">
-import {
-  definePageMeta,
-  useHead,
-  useNuxtApp,
-  useRouter,
-  useIsFormVaid,
-} from "#imports"
-
 import {useForm} from "@vorms/core"
 import {zodResolver} from "@vorms/resolvers/zod"
 
@@ -33,7 +25,7 @@ const {$trpc} = useNuxtApp()
 
 const router = useRouter()
 
-const {register, handleSubmit, errors} = useForm<IUserSignUpInput>({
+const {register, handleSubmit} = useForm<IUserSignUpInput>({
   initialValues: {
     login: "",
     email: "",
@@ -42,6 +34,7 @@ const {register, handleSubmit, errors} = useForm<IUserSignUpInput>({
   validate: zodResolver(UserSignUpInput),
   validateMode: "input",
   reValidateMode: "input",
+  validateOnMounted: true,
   async onSubmit(data) {
     try {
       await $trpc.user.create.mutate(data)
@@ -52,43 +45,75 @@ const {register, handleSubmit, errors} = useForm<IUserSignUpInput>({
   }
 })
 
-const {isInvalid} = useIsFormVaid(errors)
-
 const {value: emailValue, attrs: emailAttrs} = register("email")
-
 const {value: loginValue, attrs: loginAttrs} = register("login")
-
 const {value: passwordValue, attrs: passwordAttrs} = register("password")
 </script>
 
 <template>
-  <form @submit="handleSubmit">
-    <input
-      type="email"
-      class="border"
-      placeholder="Email"
-      v-model="emailValue"
-      v-bind="emailAttrs"
-    />
+  <FormAuth @submit="handleSubmit">
+    <template #title>
+      Signup
+    </template>
 
-    <input
-      type="text"
-      class="border"
-      placeholder="Login"
-      v-model="loginValue"
-      v-bind="loginAttrs"
-    />
+    <div class="flex flex-col gap-2">
+      <Field>
+        <Label for="email">
+          Your email
+        </Label>
 
-    <input
-      type="password"
-      class="border"
-      placeholder="Password"
-      v-model="passwordValue"
-      v-bind="passwordAttrs"
-    />
+        <Input
+          wide
+          id="email"
+          type="email"
+          placeholder="Email"
+          v-model="emailValue"
+          v-bind="emailAttrs"
+        />
+      </Field>
 
-    <button type="submit" :disabled="isInvalid">
+      <Field>
+        <Label for="login">
+          Your new login
+        </Label>
+
+        <Input
+          wide
+          id="login"
+          type="text"
+          placeholder="Login"
+          v-model="loginValue"
+          v-bind="loginAttrs"
+        />
+      </Field>
+
+      <Field>
+        <Label for="password">
+          Create a passowrd
+        </Label>
+
+        <Input
+          wide
+          id="password"
+          type="password"
+          placeholder="Password"
+          v-model="passwordValue"
+          v-bind="passwordAttrs"
+        />
+      </Field>
+    </div>
+
+    <template #submit>
       Sign up
-    </button>
-  </form>
+    </template>
+
+    <template #links>
+      <!-- <div class="h-px w-full bg-neutral-600" /> -->
+      <div class="text-center flex flex-col gap-2">
+        <NuxtLink href="/auth/login">
+          Already have an account? Log in here
+        </NuxtLink>
+      </div>
+    </template>
+  </FormAuth>
 </template>

--- a/pages/auth/signup.vue
+++ b/pages/auth/signup.vue
@@ -108,7 +108,6 @@ const {value: passwordValue, attrs: passwordAttrs} = register("password")
     </template>
 
     <template #links>
-      <!-- <div class="h-px w-full bg-neutral-600" /> -->
       <div class="text-center flex flex-col gap-2">
         <NuxtLink href="/auth/login">
           Already have an account? Log in here

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,39 @@
+import type {Config} from "tailwindcss"
+
+// Screen sizes
+const mobile = "450px"
+const laptop = "1024px"
+const desktop = "1280px"
+const xsm = mobile
+const sm = "640px"
+const md = "768px"
+const lg = laptop
+const xl = desktop
+const xl2 = "1536px"
+
+export default {
+  content: ["*.vue", "*.tsx"],
+  theme: {
+    extend: {
+      width: {
+        laptop,
+        mobile
+      },
+      maxWidth: {
+        laptop,
+        mobile
+      }
+    },
+    screens: {
+      mobile,
+      laptop,
+      desktop,
+      xsm,
+      sm,
+      md,
+      lg,
+      xl,
+      "2xl": xl2
+    }
+  }
+} satisfies Config

--- a/tailwindcss.config.ts
+++ b/tailwindcss.config.ts
@@ -1,5 +1,0 @@
-import type {Config} from "tailwindcss"
-
-export default {
-  content: ["*.vue", "*.tsx"]
-} satisfies Config


### PR DESCRIPTION
### Details

Implement styles for auth pages and support dark theme.

### Changes

- [x] Add new components: `FormAuth`, `Field`, `Button`, `Input`, and `Label`;
- [x] Add styles for `auth` layout;
- [x] Support dark theme;
- [x] Add different screen sizes and elements width to tailwind config;
- [x] Add `/auth/reset` page;
- [x] Fix: Rename tailwind config: `tailwindcss.config.ts` -> `tailwind.config.ts`

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets (optional)~~
- [x] ~~I have brought tests (if necessary)~~
