### PR TITLE
feat(avatars,server): Implement backend support for `User` avatars

### DIFF
--- a/server/db/entities/User.ts
+++ b/server/db/entities/User.ts
@@ -1,16 +1,21 @@
-import {Entity, Property, Enum, Unique} from "@mikro-orm/core"
+import {Entity, Property, Enum, Unique, OneToOne} from "@mikro-orm/core"
 
 import type {PickKeys} from "../../../lib/utils/types/PickKeys.js"
+import type {MaybeNull} from "../../..//lib/utils/types/MaybeNull.js"
 import {stringEnumValues} from "../../../lib/utils/stringEnumValues.js"
 
 import {UserStatuses} from "../../trpc/types/user/UserStatuses.js"
 import {UserRoles} from "../../trpc/types/user/UserRoles.js"
 
 import {RecordSoft} from "./RecordSoft.js"
+import {File} from "./File.js"
 
 // TODO: Add avatar field
 @Entity()
 export class User extends RecordSoft<UserOptionalProps> {
+  @Property({type: "varchar", nullable: true, default: null})
+  displayName: MaybeNull<string> = null
+
   /**
    * User unique human-readable identifier
    */
@@ -42,6 +47,13 @@ export class User extends RecordSoft<UserOptionalProps> {
    */
   @Enum({type: "string", items: stringEnumValues(UserStatuses)})
   status: UserStatuses = UserStatuses.Inactive
+
+  @OneToOne(() => File, undefined, {
+    nullable: true,
+    orphanRemoval: true,
+    default: null
+  })
+  avatar: MaybeNull<File> = null
 }
 
 type UserOptionalProps = PickKeys<User, "role" | "status">

--- a/server/trpc/routes/user.ts
+++ b/server/trpc/routes/user.ts
@@ -1,9 +1,12 @@
 import {router} from "../def.js"
 
-import {create} from "./user/create.js"
 import {getById} from "./user/getById.js"
+import {create} from "./user/create.js"
+import {update} from "./user/update.js"
 
 export const user = router({
+  getById,
+
   create,
-  getById
+  update
 })

--- a/server/trpc/routes/user/update.ts
+++ b/server/trpc/routes/user/update.ts
@@ -1,0 +1,26 @@
+import {File} from "../../../db/entities.js"
+
+import {procedure} from "../../procedures/base.js"
+import {UserOutput} from "../../types/user/UserOutput.js"
+import {UserUpdateInput} from "../../types/user/UserUpdateInput.js"
+import {withAuthContext} from "../../middlewares/withAuthContext.js"
+
+export const update = procedure
+  .use(withAuthContext)
+  .input(UserUpdateInput)
+  .output(UserOutput)
+  .mutation(async ({input, ctx: {orm, auth: {user}}}) => {
+    const {avatar, ...fields} = input
+
+    if (avatar) {
+      user.avatar = orm.em.create(File, {key: avatar})
+    } else if (avatar === null) {
+      user.avatar = null
+    }
+
+    orm.em.assign(user, fields)
+
+    await orm.em.flush()
+
+    return user
+  })

--- a/server/trpc/types/common/FileInput.ts
+++ b/server/trpc/types/common/FileInput.ts
@@ -1,0 +1,7 @@
+import {z} from "zod"
+
+export const FileInput = z.string()
+
+export type IFileInput = z.input<typeof FileInput>
+
+export type OFileInput = z.output<typeof FileInput>

--- a/server/trpc/types/common/FileOutput.ts
+++ b/server/trpc/types/common/FileOutput.ts
@@ -1,0 +1,12 @@
+import {z} from "zod"
+
+import {Record} from "./Record.js"
+import {FileInput} from "./FileInput.js"
+
+export const FileOutput = Record.extend({
+  key: FileInput
+})
+
+export type IFileOutput = z.input<typeof FileOutput>
+
+export type OFileOutput = z.output<typeof FileOutput>

--- a/server/trpc/types/user/User.ts
+++ b/server/trpc/types/user/User.ts
@@ -1,0 +1,12 @@
+import {z} from "zod"
+
+import {UserBase} from "./UserBase.js"
+import {UserDisplayName} from "./UserDisplayName.js"
+
+export const User = UserBase.extend({
+  displayName: UserDisplayName.nullish()
+})
+
+export type IUser = z.input<typeof User>
+
+export type OUser = z.output<typeof User>

--- a/server/trpc/types/user/UserBase.ts
+++ b/server/trpc/types/user/UserBase.ts
@@ -3,7 +3,6 @@ import {z} from "zod"
 import {UserLogin} from "./UserLogin.js"
 
 export const UserBase = z.object({
-  displayName: z.string().nullish(),
   login: UserLogin
 })
 

--- a/server/trpc/types/user/UserBase.ts
+++ b/server/trpc/types/user/UserBase.ts
@@ -3,6 +3,7 @@ import {z} from "zod"
 import {UserLogin} from "./UserLogin.js"
 
 export const UserBase = z.object({
+  displayName: z.string().nullish(),
   login: UserLogin
 })
 

--- a/server/trpc/types/user/UserDisplayName.ts
+++ b/server/trpc/types/user/UserDisplayName.ts
@@ -1,0 +1,3 @@
+import {z} from "zod"
+
+export const UserDisplayName = z.string().nonempty()

--- a/server/trpc/types/user/UserOutput.ts
+++ b/server/trpc/types/user/UserOutput.ts
@@ -1,9 +1,14 @@
 import {z} from "zod"
 
-import {UserRecord} from "./UserRecord.js"
-import {UserStats} from "./UserStats.js"
+import {FileOutput} from "../common/FileOutput.js"
 
-export const UserOutput = UserRecord.merge(UserStats)
+import {UserDisplayName} from "./UserDisplayName.js"
+import {UserRecord} from "./UserRecord.js"
+
+export const UserOutput = UserRecord.extend({
+  displayName: UserDisplayName.nullable(),
+  avatar: FileOutput.nullable()
+})
 
 export type IUserOutput = z.input<typeof UserOutput>
 

--- a/server/trpc/types/user/UserRecord.ts
+++ b/server/trpc/types/user/UserRecord.ts
@@ -3,8 +3,13 @@ import {z} from "zod"
 import {RecordSoft} from "../common/RecordSoft.js"
 
 import {UserNode} from "./UserNode.js"
+import {UserStats} from "./UserStats.js"
+import {User} from "./User.js"
 
-export const UserRecord = RecordSoft.merge(UserNode)
+export const UserRecord = RecordSoft
+  .merge(UserNode)
+  .merge(User)
+  .merge(UserStats)
 
 export type IUserRecord = z.input<typeof UserRecord>
 

--- a/server/trpc/types/user/UserUpdateInput.ts
+++ b/server/trpc/types/user/UserUpdateInput.ts
@@ -2,9 +2,9 @@ import {z} from "zod"
 
 import {FileInput} from "../common/FileInput.js"
 
-import {UserBase} from "./UserBase.js"
+import {User} from "./User.js"
 
-export const UserUpdateInput = UserBase.extend({
+export const UserUpdateInput = User.extend({
   avatar: FileInput.nullish()
 })
 

--- a/server/trpc/types/user/UserUpdateInput.ts
+++ b/server/trpc/types/user/UserUpdateInput.ts
@@ -1,0 +1,13 @@
+import {z} from "zod"
+
+import {FileInput} from "../common/FileInput.js"
+
+import {UserBase} from "./UserBase.js"
+
+export const UserUpdateInput = UserBase.extend({
+  avatar: FileInput.nullish()
+})
+
+export type IUserUpdateInput = z.input<typeof UserUpdateInput>
+
+export type OUserUpdateInput = z.output<typeof UserUpdateInput>


### PR DESCRIPTION
### Details

This PR bring user avatar support on the server. The changes mainly affect API and `User` model.

### Changes

- [x] Add avatar field:
  - [x] Type would be `varchar` with default length;
  - [x] Field can be nullable, and the default value must be `null`;
  - [x] It has `1:1` relation with `File` entity. It must be a one-side relation;
- [x] Add displayName field:
  - [x] Type would be `varchar` with default length;
  - [x] Field can be nullable, and the default value must be `null`;
- [x] Add both `avatar` and `displayName` to user API types;
  - [x] ...but `avatar` input type *must* be a string, while the output would be a `File`, so I'm gonna need to add:
    - [x] `FileInput` type, which is just a string. Will likely make custom validation later on;
    - [x] `FileOutput` type, which has the same fields as `File` entity;
- [x] Add `user.update` procedure. It takes `avatar` and `displayName` and returns `UserOutput`;
- [x] Expose user avatar from session callback;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets (optional)~~
- [x] ~~I have brought tests (if necessary)~~
