### PR TITLE
feat: Use SlateDescription type for Story and Chapter description

### DIFF
--- a/server/db/entities/Chapter.ts
+++ b/server/db/entities/Chapter.ts
@@ -13,6 +13,9 @@ import type {PickKeys} from "../../../lib/utils/types/PickKeys.js"
 import type {
   ORootElements
 } from "../../trpc/types/common/slate/RootElements.js"
+import type {
+  OSlateDescription
+} from "../../trpc/types/common/slate/SlateDescription.js"
 
 import {RecordSoft} from "./RecordSoft.js"
 import {Story} from "./Story.js"
@@ -35,8 +38,8 @@ export class Chapter extends RecordSoft<ChapterOptionalProps> {
   /**
    * Chapter description
    */
-  @Property({type: "text", lazy: true})
-  description!: string
+  @Property({type: JsonType, lazy: true})
+  description!: OSlateDescription
 
   /**
    * Chapter content.

--- a/server/db/entities/Story.ts
+++ b/server/db/entities/Story.ts
@@ -4,11 +4,15 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
-  Collection
+  Collection,
+  JsonType
 } from "@mikro-orm/core"
 
 import type {PickKeys} from "../../../lib/utils/types/PickKeys.js"
 import type {StorySlug} from "../../lib/utils/slug/storySlug.js"
+import type {
+  OSlateDescription
+} from "../../trpc/types/common/slate/SlateDescription.js"
 
 import {RecordSoft} from "./RecordSoft.js"
 import {Chapter} from "./Chapter.js"
@@ -26,8 +30,8 @@ export class Story extends RecordSoft<StoryOptionalProps> {
   /**
    * Story description
    */
-  @Property({type: "text", lazy: true}) // FIXME: Chose precise type for description, MySQL has different variants for TEXT
-  description!: string
+  @Property({type: JsonType, lazy: true})
+  description!: OSlateDescription
 
   /**
    * URL-friendly & human-readable story identifier

--- a/server/trpc/routes/stories/list.trpc.test.ts
+++ b/server/trpc/routes/stories/list.trpc.test.ts
@@ -23,9 +23,14 @@ describe("stories.list procedure", async () => {
     })
 
     const createStories = () => em.create(Story, {
+      publisher: user,
       title: faker.lorem.words({min: 3, max: 6}),
-      description: faker.lorem.paragraph(),
-      publisher: user
+      description: [{
+        type: "p",
+        children: [{
+          text: faker.lorem.paragraph()
+        }]
+      }]
     })
 
     const stories = faker.helpers.multiple(createStories, {count})

--- a/server/trpc/routes/story/create.trpc.test.ts
+++ b/server/trpc/routes/story/create.trpc.test.ts
@@ -12,19 +12,28 @@ describe("story.create procedure", async () => {
   trpcTest.concurrent("creates a new story", async ({expect, trpc}) => {
     const expected = {
       title: faker.lorem.words({min: 3, max: 6}),
-      description: faker.lorem.paragraph()
+      description: [{
+        type: "p",
+        children: [{
+          text: faker.lorem.paragraph()
+        }]
+      }]
     } satisfies IStoryCreateInput
 
     const actual = await trpc.story.create(expected)
 
-    expect(actual.title).to.equal(expected.title)
-    expect(actual.description).to.equal(expected.description)
+    expect(actual).toMatchObject(expected)
   })
 
   trpcTest.concurrent("generates slug", async ({expect, trpc, orm}) => {
     const actual = await trpc.story.create({
       title: faker.lorem.words({min: 3, max: 6}),
-      description: faker.lorem.paragraph()
+      description: [{
+        type: "p",
+        children: [{
+          text: faker.lorem.paragraph()
+        }]
+      }]
     })
 
     const expected = await orm.em.findOneOrFail(Story, actual.id, {
@@ -41,7 +50,12 @@ describe("story.create procedure", async () => {
   }) => {
     const {publisher} = await trpc.story.create({
       title: faker.lorem.words({min: 3, max: 6}),
-      description: faker.lorem.paragraph()
+      description: [{
+        type: "p",
+        children: [{
+          text: faker.lorem.paragraph()
+        }]
+      }]
     })
 
     expect(publisher.id).to.equal(auth!.id)

--- a/server/trpc/routes/story/getBySlug.trpc.test.ts
+++ b/server/trpc/routes/story/getBySlug.trpc.test.ts
@@ -13,9 +13,14 @@ describe("story.getBySlug procedure", async () => {
     })
 
     const story = orm.em.create(Story, {
+      publisher: user,
       title: faker.lorem.words({min: 2, max: 5}),
-      description: faker.lorem.paragraph(),
-      publisher: user
+      description: [{
+        type: "p",
+        children: [{
+          text: faker.lorem.paragraph()
+        }]
+      }]
     })
 
     await orm.em.persistAndFlush([user, story])

--- a/server/trpc/types/chapter/ChapterBase.ts
+++ b/server/trpc/types/chapter/ChapterBase.ts
@@ -1,8 +1,10 @@
 import {z} from "zod"
 
+import {SlateDescription} from "../common/slate/SlateDescription.js"
+
 export const ChapterBase = z.object({
   title: z.string().min(2),
-  description: z.string().min(2),
+  description: SlateDescription,
   isDraft: z.boolean(),
   order: z.number().int().positive()
 })

--- a/server/trpc/types/common/slate/SlateDescription.ts
+++ b/server/trpc/types/common/slate/SlateDescription.ts
@@ -1,0 +1,9 @@
+import {z} from "zod"
+
+import {Paragraph} from "./Paragraph.js"
+
+export const SlateDescription = z.array(Paragraph).nonempty()
+
+export type ISlateDescription = z.input<typeof SlateDescription>
+
+export type OSlateDescription = z.output<typeof SlateDescription>

--- a/server/trpc/types/story/StoryWithDescription.ts
+++ b/server/trpc/types/story/StoryWithDescription.ts
@@ -1,7 +1,9 @@
 import {z} from "zod"
 
+import {SlateDescription} from "../common/slate/SlateDescription.js"
+
 export const StoryWithDescription = z.object({
-  description: z.string().min(2)
+  description: SlateDescription
 })
 
 export type IStoryWithDescription = z.input<typeof StoryWithDescription>


### PR DESCRIPTION
### Details

This PR changes description type for Story and Chapter to make for further integration with Slate.

### Changes

- [x] Add `SlateDescription type`;
- [x] Update Story and Chapter entities and zod types for their API;
- [x] Fix tests to reflect changes;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets (optional)~~
- [x] I have brought tests (if necessary)
