### PR TITLE
feat(avatar): UI improvements for avatars cropping

### DIFF
--- a/components/AvatarEditable.vue
+++ b/components/AvatarEditable.vue
@@ -144,7 +144,7 @@ onUnmounted(() => {
       <template #default="{close}">
         <div class="p-6">
           <CropImage round :preview="preview" alt="Avatar" @crop="onCrop">
-            <template #default="{click}">
+            <template #default="{crop}">
               <div class="flex">
                 <Button variant="secondary" @click="close">
                   Cancel
@@ -152,7 +152,7 @@ onUnmounted(() => {
 
                 <div class="flex-1" />
 
-                <Button @click="click">
+                <Button @click="crop">
                   Save
                 </Button>
               </div>

--- a/components/AvatarEditable.vue
+++ b/components/AvatarEditable.vue
@@ -9,6 +9,8 @@ import type {MaybeUndefined} from "../lib/utils/types/MaybeUndefined.js"
 
 import type {AvatarProps} from "./Avatar.vue"
 
+import Modal from "./Modal.vue"
+
 defineProps<AvatarProps>()
 
 const {$trpc} = useNuxtApp()
@@ -25,6 +27,7 @@ const uppy = new Uppy({
     endpoint: "/uploads"
   })
 
+const modalRef = ref<InstanceType<typeof Modal>>()
 const preview = ref<MaybeUndefined<string>>()
 const selected = ref<File>()
 
@@ -63,7 +66,7 @@ function updateFile(file: File): string {
   return id
 }
 
-const onChange = (files: File[] | null) => {
+const onFileSelected = (files: File[] | null) => {
   if (!files) {
     return
   }
@@ -77,6 +80,8 @@ const onChange = (files: File[] | null) => {
     selected.value = file
 
     updatePreview(selected.value)
+
+    modalRef.value?.open()
   } catch (error) {
     console.error(error)
   }
@@ -104,8 +109,16 @@ function onCrop(blob: Blob) {
       // Update user avatar
       await $trpc.user.update.mutate({avatar: uploaded.uploadURL})
       await getSession()
+
+      if (modalRef.value) {
+        modalRef.value.close()
+      }
     })
     .catch(console.error)
+}
+
+function onModalClose() {
+  cleanup()
 }
 
 onUnmounted(() => {
@@ -115,32 +128,38 @@ onUnmounted(() => {
 
 <template>
   <Avatar class="relative" v-bind="$props">
-    <Modal @close="cleanup">
-      <template #openButton="{openDialog}">
-        <button
-          class="absolute bottom-0 right-0 w-6 h-6 flex justify-center items-center bg-black rounded-full"
+    <InputFile
+      plain
+      class="absolute bottom-0 right-0 w-6 h-6 flex justify-center items-center bg-black rounded-full"
+      @change="onFileSelected"
+    >
+      <Pencil :size="16" />
+    </InputFile>
 
-          @click="openDialog"
-        >
-          <Pencil :size="16" />
-        </button>
-      </template>
-
+    <Modal ref="modalRef" @close="onModalClose">
       <template #title>
-        Update avatar
+        Crop
       </template>
 
-      <div class="p-6">
-        <div v-if="preview" class="overflow-hidden">
-          <CropImage round :src="preview" alt="Avatar" @crop="onCrop" />
-        </div>
+      <template #default="{close}">
+        <div class="p-6">
+          <CropImage round :preview="preview" alt="Avatar" @crop="onCrop">
+            <template #default="{click}">
+              <div class="flex">
+                <Button variant="secondary" @click="close">
+                  Cancel
+                </Button>
 
-        <div class="pt-5">
-          <InputFile @change="onChange">
-            Choose a file
-          </InputFile>
+                <div class="flex-1" />
+
+                <Button @click="click">
+                  Save
+                </Button>
+              </div>
+            </template>
+          </CropImage>
         </div>
-      </div>
+      </template>
     </Modal>
   </Avatar>
 </template>

--- a/components/Button.vue
+++ b/components/Button.vue
@@ -6,7 +6,7 @@ type Colors = "red" | "brand"
 type Shapes = "square" | "circle"
 
 // ! Vue doesn't support this kind of props
-interface Props {
+export interface ButtonProps {
   variant?: Variants
   color?: Colors
   shape?: Shapes
@@ -16,7 +16,7 @@ interface Props {
   plain?: boolean
 }
 
-withDefaults(defineProps<Props>(), {
+withDefaults(defineProps<ButtonProps>(), {
   color: "brand",
   variant: "primary",
   shape: "square",
@@ -43,7 +43,7 @@ withDefaults(defineProps<Props>(), {
         'disabled:bg-gray-400 disabled:dark:bg-slate-600': (variant === 'primary' && !loading),
         'disabled:border-gray-300 disabled:text-gray-300 bg-transparent active:disabled:bg-transparent dark:disabled:border-slate-500 dark:disabled:text-slate-500': variant === 'secondary',
         'bg-violet-500 active:bg-violet-600 border-violet-500 text-white': variant === 'primary' && (!color || color === 'brand'),
-        'bg-white active:bg-gray-200 dark:bg-slate-700 dark:text-white dark:active:bg-slate-600': variant === 'secondary',
+        'bg-white active:bg-gray-200 dark:bg-transparent dark:text-white dark:active:bg-slate-600': variant === 'secondary',
         'border-gray-200 bg-white active:bg-gray-200 text-black': variant === 'secondary' && !color,
         'bg-red-500 active:bg-red-600 text-white': variant === 'primary' && color === 'red',
         'border-violet-500 text-violet-500 active:bg-violet-200': variant === 'secondary' && color === 'brand',

--- a/components/CropImage.vue
+++ b/components/CropImage.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+/* eslint-disable @typescript-eslint/indent */
+
 import "cropperjs/dist/cropper.css"
 
 import Cropper from "cropperjs"
@@ -17,17 +19,18 @@ export type CropImageOptions = Omit<
 
 export interface CropImageProps {
   round?: boolean
-  src: string
-  alt?: string,
+  preview: string
   options?: CropImageOptions
+  alt?: string
 }
 
 const props = withDefaults(defineProps<CropImageProps>(), {
+  preview: undefined,
   round: false,
   alt: "",
   options: () => ({
     aspectRatio: 1,
-    viewMode: 2,
+    viewMode: 3,
     dragMode: "none",
     zoomable: false,
     autoCropArea: 1,
@@ -46,17 +49,10 @@ onMounted(() => {
   }
 })
 
-onUnmounted(() => {
-  if (cropper.value) {
-    cropper.value.replace("") // A hack to prevent error because the image is removed before unmount
-    cropper.value.destroy()
-  }
-})
-
 onUpdated(() => {
-  if (cropper.value) {
+  if (cropper.value && props.preview) {
     // FIXME: Fix image flickering once it replaced
-    cropper.value.replace(props.src)
+    cropper.value.replace(props.preview)
   }
 })
 
@@ -87,12 +83,10 @@ function crop(): void {
 
 <template>
   <div :class="['w-full', {'round-crop': round}]">
-    <div class="w-full">
-      <img ref="el" :src="src" :alt="alt" class="block max-w-full" />
+    <div class="w-full mb-5 overflow-hidden" :style="{aspectRatio: options.aspectRatio}">
+      <img ref="el" :src="preview" :alt="alt" class="block max-w-full" />
     </div>
 
-    <button type="button" @click="crop">
-      Crop
-    </button>
+    <slot :click="crop" />
   </div>
 </template>

--- a/components/CropImage.vue
+++ b/components/CropImage.vue
@@ -87,6 +87,6 @@ function crop(): void {
       <img ref="el" :src="preview" :alt="alt" class="block max-w-full" />
     </div>
 
-    <slot :click="crop" />
+    <slot :crop="crop" />
   </div>
 </template>

--- a/components/InputFile.vue
+++ b/components/InputFile.vue
@@ -2,7 +2,9 @@
 import type {MaybeNull} from "../lib/utils/types/MaybeNull"
 import {toFilesArray} from "../lib/utils/toFilesArray.js"
 
-export interface InputFileProps {
+import type {ButtonProps} from "./Button.vue"
+
+export interface InputFileProps extends ButtonProps {
   multiple?: boolean
   accept?: string
 }
@@ -29,7 +31,7 @@ function onChange(event: Event) {
 </script>
 
 <template>
-  <Button type="button" @click="inputRef?.click()">
+  <Button v-bind="$props" type="button" @click="inputRef?.click()">
     <input ref="inputRef" type="file" class="hidden" v-bind="{accept, multiple}" @change="onChange" />
     <slot />
   </Button>


### PR DESCRIPTION
### Details

This PR improves avatars crop UI and changes the way user selects a new avatar, so this is now more straightforward.

### Changes

- [x] Open file select right from AvatarEditable component;
- [x] Improve UI for AvatarEditable modal;
- [x] Tweak Cropper.js UI and improve CropImage component:
  - [x] Show previews with correct aspect ratio styles (can be set via component props);
  - [x] Change Cropper.js preview mode to the 3rd;
  - [x] Make preview property required;
  - [x] Add default slot to show custom action buttons. This slot exposes a `crop` function that triggers `cropper.crop()`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets (optional)~~
- [x] ~~I have brought tests (if necessary)~~
