### PR TITLE
feat(ui): Add daisyui

### DIFF
--- a/components/Field.vue
+++ b/components/Field.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-2">
+  <div class="form-control gap-2">
     <slot />
   </div>
 </template>

--- a/components/Form/Auth.vue
+++ b/components/Form/Auth.vue
@@ -10,9 +10,9 @@
 
     <div>
       <slot name="actions">
-        <Button wide type="submit">
+        <button type="submit" class="btn btn-block btn-primary no-animation">
           <slot name="submit" />
-        </Button>
+        </button>
       </slot>
     </div>
 

--- a/components/FullscreenMain.vue
+++ b/components/FullscreenMain.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="w-screen h-[100dvh] flex">
+  <main class="w-screen min-h-[100dvh] flex">
     <slot />
   </main>
 </template>

--- a/components/Input.vue
+++ b/components/Input.vue
@@ -8,10 +8,18 @@ defineProps<Props>()
 defineEmits(["update:modelValue"])
 </script>
 
+<style>
+.input-ghost {
+  &, &:focus, &:focus-within {
+    @apply bg-transparent;
+  }
+}
+</style>
+
 <template>
   <input
     :class="[
-      'p-3 border border-gray-300 text-neutral-500 dark:text-neutral-400 rounded-md dark:bg-neutral-800 dark:border-neutral-600',
+      'input input-ghost input-bordered',
 
       {
         'w-full': wide === true

--- a/components/Label.vue
+++ b/components/Label.vue
@@ -1,5 +1,7 @@
 <template>
-  <label class="w-full text-neutral-500 dark:text-neutral-400">
-    <slot />
+  <label class="label">
+    <span class="label-text">
+      <slot />
+    </span>
   </label>
 </template>

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@unhead/vue": "^1.7.4",
     "@vitejs/plugin-vue": "4.4.0",
     "cookie": "0.5.0",
+    "daisyui": "^3.9.3",
     "eslint": "8.51.0",
     "eslint-plugin-vue": "9.17.0",
     "execa": "8.0.1",
@@ -74,6 +75,7 @@
     "nuxt-svgo": "3.5.5",
     "tailwindcss": "^3.3.3",
     "ts-node": "10.9.1",
+    "vite": "^4.4.11",
     "vitest": "0.34.4",
     "vue": "^3.3.4",
     "vue-router": "^4.2.5"
@@ -99,6 +101,7 @@
     "cropperjs": "1.6.1",
     "date-fns": "2.30.0",
     "fs-extra": "11.1.1",
+    "h3": "^1.8.2",
     "lodash-es": "4.17.21",
     "lucide-vue-next": "0.287.0",
     "mime-types": "2.1.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ dependencies:
   fs-extra:
     specifier: 11.1.1
     version: 11.1.1
+  h3:
+    specifier: ^1.8.2
+    version: 1.8.2
   lodash-es:
     specifier: 4.17.21
     version: 4.17.21
@@ -184,6 +187,9 @@ devDependencies:
   cookie:
     specifier: 0.5.0
     version: 0.5.0
+  daisyui:
+    specifier: ^3.9.3
+    version: 3.9.3(ts-node@10.9.1)
   eslint:
     specifier: 8.51.0
     version: 8.51.0
@@ -214,6 +220,9 @@ devDependencies:
   ts-node:
     specifier: 10.9.1
     version: 10.9.1(@types/node@20.8.6)(typescript@5.2.2)
+  vite:
+    specifier: ^4.4.11
+    version: 4.4.11(@types/node@20.8.6)
   vitest:
     specifier: 0.34.4
     version: 0.34.4(jsdom@22.1.0)
@@ -4306,6 +4315,13 @@ packages:
       domutils: 3.1.0
       nth-check: 2.1.1
 
+  /css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+    dev: true
+
   /css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
@@ -4412,6 +4428,19 @@ packages:
   /custom-error-instance@2.1.1:
     resolution: {integrity: sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==}
     dev: false
+
+  /daisyui@3.9.3(ts-node@10.9.1):
+    resolution: {integrity: sha512-8li177QCu6dqlEOzE3h/dAV1y9Movbjx5bzJIO/hNqMNZtJkbHM0trjTzbDejV7N57eNGdjBvAGtxZYKzS4jow==}
+    engines: {node: '>=16.9.0'}
+    dependencies:
+      colord: 2.9.3
+      css-selector-tokenizer: 0.8.0
+      postcss: 8.4.31
+      postcss-js: 4.0.1(postcss@8.4.31)
+      tailwindcss: 3.3.3(ts-node@10.9.1)
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
 
   /dargs@7.0.0:
     resolution: {integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==}
@@ -5438,6 +5467,10 @@ packages:
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  /fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
+    dev: true
 
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,8 @@
+import type {Config as DaisyUIConfig} from "daisyui"
 import type {Config} from "tailwindcss"
+
+import colors from "tailwindcss/colors.js"
+import themes from "daisyui/src/theming/themes.js"
 
 import headlessui from "@headlessui/tailwindcss"
 import daisyui from "daisyui"
@@ -41,5 +45,24 @@ export default {
       xl,
       "2xl": xl2
     }
-  }
+  },
+  daisyui: {
+    base: false,
+    themes: [
+      {
+        light: {
+          ...themes["[data-theme=light]"],
+          primary: colors.violet["500"],
+          "primary-focus": colors.violet["600"],
+          "primary-content": colors.white
+        },
+        dark: {
+          ...themes["[data-theme=dark]"],
+          primary: colors.violet["500"],
+          "primary-focus": colors.violet["600"],
+          "primary-content": colors.white
+        }
+      }
+    ]
+  } as DaisyUIConfig
 } satisfies Config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type {Config} from "tailwindcss"
 
 import headlessui from "@headlessui/tailwindcss"
+import daisyui from "daisyui"
 
 // Screen sizes
 const mobile = "450px"
@@ -15,7 +16,7 @@ const xl2 = "1536px"
 
 export default {
   content: ["*.vue", "*.tsx"],
-  plugins: [headlessui],
+  plugins: [headlessui, daisyui],
   theme: {
     extend: {
       width: {


### PR DESCRIPTION
### Details

This PR introduces [`daisyui`](https://daisyui.com/) components.

### Changes

- [x] Add daisyui plugin to `tailwind.config.ts`;
- [x] Configure some of the colors for daisyui components for light and dark themes;
- [x] Use daisyui components for buttons and input on auth pages;
- [x] Add missing dependencies: `vite` and `h3`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets~~ <!-- optional -->
- [x] ~~I have brought tests~~ <!-- if necessary -->
