### PR TITLE
feat(story): Add story page draft and introduce composable loaders

### DIFF
--- a/composables/useStoryGetBySlug.ts
+++ b/composables/useStoryGetBySlug.ts
@@ -1,0 +1,31 @@
+import type {inferProcedureInput, inferProcedureOutput} from "@trpc/server"
+
+import type {Router} from "../server/trpc/router.js"
+
+import {
+  isNuxtTrpcNotFoundError
+} from "../lib/trpc/isNuxtTrpcNotFoundError.js"
+import {notFound} from "../lib/errors/nuxt/notFound.js"
+
+type Procedure = Router["story"]["getBySlug"]
+
+type Slug = inferProcedureInput<Procedure>["slug"]
+
+type Result = inferProcedureOutput<Procedure>
+
+/**
+ * Returns a story by given `slug`
+ *
+ * Throws `404` error if no matched story has been found
+ */
+export async function useStoryGetBySlug(slug: Slug): Promise<Ref<Result>> {
+  const {$trpc} = useNuxtApp()
+
+  const {error, data} = await $trpc.story.getBySlug.useQuery({slug})
+
+  if (isNuxtTrpcNotFoundError(error)) {
+    notFound()
+  }
+
+  return data as Ref<NonNullable<typeof data.value>>
+}

--- a/lib/errors/nuxt/notFound.ts
+++ b/lib/errors/nuxt/notFound.ts
@@ -1,0 +1,3 @@
+export function notFound(message?: string): never {
+  throw createError({statusCode: 404, message})
+}

--- a/lib/trpc/isNuxtTrpcError.ts
+++ b/lib/trpc/isNuxtTrpcError.ts
@@ -1,0 +1,26 @@
+import type {TRPCError} from "@trpc/server"
+import {isObjectLike} from "lodash-es"
+
+interface NuxtTrpcErrorData {
+  code: TRPCError["code"]
+  httpStatus: number
+  stack: string
+}
+
+export type NuxtTrpcError = Omit<ReturnType<typeof createError>, "data"> & {
+  data: NuxtTrpcErrorData
+}
+
+export function isNuxtTrpcError(input: MaybeRef<unknown>): input is NuxtTrpcError {
+  const value = unref(input) as NuxtTrpcError
+
+  if (!isObjectLike(value) || Array.isArray(value)) {
+    return false
+  }
+
+  if (!isNuxtError(value)) {
+    return false
+  }
+
+  return "code" in value.data && "httpStatus" in value.data
+}

--- a/lib/trpc/isNuxtTrpcNotFoundError.ts
+++ b/lib/trpc/isNuxtTrpcNotFoundError.ts
@@ -1,0 +1,5 @@
+import {isNuxtTrpcError} from "./isNuxtTrpcError.js"
+
+export const isNuxtTrpcNotFoundError = (
+  input: MaybeRef<unknown>
+) => isNuxtTrpcError(input) && unref(input).data.code === "NOT_FOUND"

--- a/pages/story/[name]~[suffix]/index.vue
+++ b/pages/story/[name]~[suffix]/index.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+const {params} = useRoute()
+
+interface Params {
+  name: string
+  suffix: string
+}
+
+const {name, suffix} = params as unknown as Params
+
+const story = await useStoryGetBySlug({name, suffix})
+</script>
+
+<template>
+  <div>{{story.title}}</div>
+</template>

--- a/server/trpc/types/story/slug/StorySlug.ts
+++ b/server/trpc/types/story/slug/StorySlug.ts
@@ -23,12 +23,12 @@ export const StorySlug = transform(
     }
 
     if (Array.isArray(slug)) {
-      const [date, name] = slug
+      const [name, suffix] = slug
 
-      return `${date}~${name}`
+      return `${name}~${suffix}`
     }
 
-    return `${slug.date}~${slug.name}`
+    return `${slug.name}~${slug.suffix}`
   }
 )
 

--- a/server/trpc/types/story/slug/StorySlugObject.ts
+++ b/server/trpc/types/story/slug/StorySlugObject.ts
@@ -6,7 +6,7 @@ import {name} from "./utils/name.js"
 
 export const StorySlugObject = object({
   name: string([name()]),
-  date: string([suffix()])
+  suffix: string([suffix()])
 })
 
 export type IStorySlugObject = Input<typeof StorySlugObject>


### PR DESCRIPTION
### Details

This PR introduces composable loader as minimal abstraction for tRPC queries and adds story page.

Unfortunately I wasn't able to create a proper abstraction for such composables using `createTrpcLoader` factory that was planned. I was supposed to take an implementation function, infer the implementation's result and arguments and add `trpc` client instance as the first argument. But it appears to me that results of `useNuxtApp` call are inaccessible from within such factory functions, so I decided to not included this implementation and stick with a simple solution.

### Changes

- [x] Add story page available by the `/story/[name]~[suffix]` path;
- [x] Add `useStoryGetBySlug` composable as demonstration for trpc composable loaders abstraction;
- [x] Fix for story slug validation;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
