### PR TITLE
fix(pages): Use useHeadSafe instead of useHead to define head attributes on pages

### DIFF
--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -10,7 +10,7 @@ definePageMeta({
   } satisfies AuthMeta
 })
 
-useHead({
+useHeadSafe({
   title: "Login"
 })
 

--- a/pages/auth/reset.vue
+++ b/pages/auth/reset.vue
@@ -3,7 +3,7 @@ import {noop} from "lodash-es"
 
 import type {AuthMeta} from "../../lib/auth/AuthMeta.js"
 
-useHead({
+useHeadSafe({
   title: "Reset password"
 })
 

--- a/pages/auth/signup.vue
+++ b/pages/auth/signup.vue
@@ -10,7 +10,7 @@ definePageMeta({
   } satisfies AuthMeta
 })
 
-useHead({
+useHeadSafe({
   title: "Signup"
 })
 

--- a/pages/story/[name]~[suffix]/index.vue
+++ b/pages/story/[name]~[suffix]/index.vue
@@ -9,6 +9,10 @@ interface Params {
 const {name, suffix} = params as unknown as Params
 
 const story = await useStoryGetBySlug({name, suffix})
+
+useHeadSafe({
+  title: story.value.title
+})
 </script>
 
 <template>


### PR DESCRIPTION
### Details

This PR uses safe version of useHead composable to prevent potential security issues with user-defined metadata.

### Changes

- [x] Use `useHeadSafe` instead of `useHead`;

### Checklist

- [x] I have self-reviewed my changes before asking for a review from maintainers
- [x] ~~I have added changesets <!-- optional -->~~
- [x] ~~I have brought tests <!-- if necessary -->~~
